### PR TITLE
update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Description
+
+Please provide a brief description of the changes introduced by this pull request.
+
+## Related Issue
+
+- [Issue Number](link-to-issue): Brief description
+
+## Checklist
+
+Please ensure that the following steps are completed before submitting the pull request:
+
+- [ ] Code follows the Terraform best practices and style guidelines.
+- [ ] Changes are appropriately documented, including any necessary updates to README or other documentation files.
+- [ ] Unit tests have been added or updated to cover the changes introduced by this pull request.
+- [ ] Changes have been tested locally and verified to work as expected.
+- [ ] The code has been reviewed to ensure it aligns with the project's goals and standards.
+- [ ] Dependencies and backward compatibility have been considered and addressed if applicable.
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Intermediate change (work in progress)
+
+## Testing Instructions
+
+Provide detailed steps or instructions for testing the changes introduced by this pull request.
+
+## Screenshots
+
+Include any relevant screenshots or visual aids to help reviewers understand the changes visually, if applicable.
+
+## Additional Notes
+
+Add any additional notes or context that might be helpful for reviewers or users testing the changes.


### PR DESCRIPTION
GitHub issue templates are customizable forms that guide users in submitting consistent and informative bug reports, feature requests, or any other type of issue on a GitHub repository. They streamline the issue creation process by providing predefined fields and prompts, ensuring that crucial information is included in each submission. This helps maintain organized communication between contributors and project maintainers, leading to more efficient issue resolution.

